### PR TITLE
[Feat/#83] security bug fix

### DIFF
--- a/src/main/kotlin/com/grepp/nbe1_3_team04/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/config/SecurityConfig.kt
@@ -1,26 +1,21 @@
 package com.grepp.nbe1_3_team04.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.grepp.nbe1_3_team04.global.api.ApiResponse
-import com.grepp.nbe1_3_team04.global.exception.ExceptionHandlerFilter
+import com.grepp.nbe1_3_team04.global.exception.filter.CustomAccessDeniedHandler
+import com.grepp.nbe1_3_team04.global.exception.filter.CustomAuthenticationEntryPoint
+import com.grepp.nbe1_3_team04.global.exception.filter.ExceptionHandlerFilter
 import com.grepp.nbe1_3_team04.member.domain.MemberRole
 import com.grepp.nbe1_3_team04.member.jwt.JwtTokenFilter
-import com.grepp.nbe1_3_team04.member.oauth2.CustomOAuth2LoginSuccessHandler
 import com.grepp.nbe1_3_team04.member.oauth2.CustomOAuth2UserService
-import jakarta.servlet.http.HttpServletRequest
-import jakarta.servlet.http.HttpServletResponse
+import com.grepp.nbe1_3_team04.member.oauth2.handler.CustomOAuth2LoginFailureHandler
+import com.grepp.nbe1_3_team04.member.oauth2.handler.CustomOAuth2LoginSuccessHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Primary
-import org.springframework.http.HttpStatus
-import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.client.RestTemplate
 
@@ -30,7 +25,9 @@ import org.springframework.web.client.RestTemplate
 class SecurityConfig(private val jwtTokenFilter: JwtTokenFilter,
                      private val exceptionHandlerFilter: ExceptionHandlerFilter,
                      private val customOAuth2UserService: CustomOAuth2UserService,
-                     private val customOAuth2LoginSuccessHandler: CustomOAuth2LoginSuccessHandler) {
+                     private val customOAuth2LoginSuccessHandler: CustomOAuth2LoginSuccessHandler,
+                     private val customOAuth2LoginFailureHandler: CustomOAuth2LoginFailureHandler
+) {
 
     private val loginUrls = arrayOf("/api/v1/members/join", "/api/v1/members/login")
     private val permitUrls = arrayOf("/api/v1/court/**", "/api/v1/stadium/**","/api/v1/team/{teamId}/info","/ws", "/h2-console", "/h2-console/**")
@@ -62,32 +59,27 @@ class SecurityConfig(private val jwtTokenFilter: JwtTokenFilter,
             .oauth2Login {
                 it.userInfoEndpoint { it.userService(customOAuth2UserService) }
                     .successHandler(customOAuth2LoginSuccessHandler)
+                    .failureHandler(customOAuth2LoginFailureHandler)
             }
             .headers { headerConfig ->
                 headerConfig.frameOptions { it.sameOrigin() }
             }
             .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
             .addFilterBefore(exceptionHandlerFilter, JwtTokenFilter::class.java)
-            .exceptionHandling { it.accessDeniedHandler(accessDeniedHandler()) }
+            .exceptionHandling {
+                it.authenticationEntryPoint(authenticationEntryPoint())
+                it.accessDeniedHandler(accessDeniedHandler()) }
 
         return http.build()
     }
 
     @Bean
-    fun accessDeniedHandler(): AccessDeniedHandler {
-        return AccessDeniedHandler { _: HttpServletRequest?, response: HttpServletResponse, _: AccessDeniedException? ->
-            val objectMapper = ObjectMapper()
-            response.status = HttpServletResponse.SC_FORBIDDEN
-            response.contentType = "application/json"
-            val apiResponse: ApiResponse<Any?> = ApiResponse.of(
-                HttpStatus.FORBIDDEN,
-                "권한이 없습니다.",
-                null
-            )
+    fun accessDeniedHandler(): CustomAccessDeniedHandler {
+        return CustomAccessDeniedHandler()
+    }
 
-            val jsonResponse = objectMapper.writeValueAsString(apiResponse)
-            response.characterEncoding = "UTF-8"
-            response.writer.write(jsonResponse)
-        }
+    @Bean
+    fun authenticationEntryPoint(): CustomAuthenticationEntryPoint {
+        return CustomAuthenticationEntryPoint()
     }
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/CustomAccessDeniedHandler.kt
@@ -1,0 +1,30 @@
+package com.grepp.nbe1_3_team04.global.exception.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.grepp.nbe1_3_team04.global.api.ApiResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+
+class CustomAccessDeniedHandler : AccessDeniedHandler {
+    override fun handle(
+        request: HttpServletRequest?,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException?
+    ) {
+        val objectMapper = ObjectMapper()
+        response.status = HttpServletResponse.SC_FORBIDDEN
+        response.contentType = "application/json"
+        val apiResponse: ApiResponse<Any?> = ApiResponse.of(
+            HttpStatus.FORBIDDEN,
+            "권한이 없습니다.",
+            null
+        )
+
+        val jsonResponse = objectMapper.writeValueAsString(apiResponse)
+        response.characterEncoding = "UTF-8"
+        response.writer.write(jsonResponse)
+    }
+}

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,34 @@
+package com.grepp.nbe1_3_team04.global.exception.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.grepp.nbe1_3_team04.global.api.ApiResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import java.io.IOException
+
+
+@Component
+class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
+    @Throws(IOException::class)
+    override fun commence(
+        request: HttpServletRequest?,
+        response: HttpServletResponse,
+        authException: org.springframework.security.core.AuthenticationException?
+    ) {
+        val objectMapper = ObjectMapper()
+        response.status = HttpServletResponse.SC_UNAUTHORIZED
+        response.contentType = "application/json"
+        val apiResponse: ApiResponse<Any?> = ApiResponse.of(
+            HttpStatus.UNAUTHORIZED,
+            "인증 정보가 없습니다.",
+            null
+        )
+
+        val jsonResponse = objectMapper.writeValueAsString(apiResponse)
+        response.characterEncoding = "UTF-8"
+        response.writer.write(jsonResponse)
+    }
+}

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/CustomAuthenticationEntryPoint.kt
@@ -23,7 +23,7 @@ class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
         response.contentType = "application/json"
         val apiResponse: ApiResponse<Any?> = ApiResponse.of(
             HttpStatus.UNAUTHORIZED,
-            "인증 정보가 없습니다.",
+            "요청 혹은 인증 정보에 오류가 있습니다.",
             null
         )
 

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/ExceptionHandlerFilter.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/ExceptionHandlerFilter.kt
@@ -1,4 +1,4 @@
-package com.grepp.nbe1_3_team04.global.exception
+package com.grepp.nbe1_3_team04.global.exception.filter
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.grepp.nbe1_3_team04.global.api.ApiResponse
@@ -33,6 +33,9 @@ class ExceptionHandlerFilter : OncePerRequestFilter() {
         }  catch (e: IllegalArgumentException){
             log.error(e.message)
             setErrorResponse(HttpStatus.BAD_REQUEST, response, e)
+        } catch (e: Exception){
+            log.error(e.message)
+            setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response, e)
         }
     }
 

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/ExceptionHandlerFilter.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/ExceptionHandlerFilter.kt
@@ -2,10 +2,7 @@ package com.grepp.nbe1_3_team04.global.exception.filter
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.grepp.nbe1_3_team04.global.api.ApiResponse
-import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.JwtException
-import io.jsonwebtoken.MalformedJwtException
-import io.jsonwebtoken.UnsupportedJwtException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
 import jakarta.servlet.http.HttpServletRequest

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/ExceptionHandlerFilter.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/filter/ExceptionHandlerFilter.kt
@@ -2,7 +2,10 @@ package com.grepp.nbe1_3_team04.global.exception.filter
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.grepp.nbe1_3_team04.global.api.ApiResponse
+import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.MalformedJwtException
+import io.jsonwebtoken.UnsupportedJwtException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
 import jakarta.servlet.http.HttpServletRequest
@@ -27,15 +30,18 @@ class ExceptionHandlerFilter : OncePerRequestFilter() {
     ) {
         try {
             filterChain.doFilter(request, response)
-        } catch (e: JwtException) {
-            log.error(e.message)
-            setErrorResponse(HttpStatus.UNAUTHORIZED, response, e)
-        }  catch (e: IllegalArgumentException){
-            log.error(e.message)
-            setErrorResponse(HttpStatus.BAD_REQUEST, response, e)
-        } catch (e: Exception){
-            log.error(e.message)
-            setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response, e)
+        } catch (e: Exception) {
+            when (e) {
+                is JwtException -> {
+                    log.error(e.message)
+                    setErrorResponse(HttpStatus.UNAUTHORIZED, response, e)
+                }
+
+                else -> {
+                    log.error(e.message)
+                    setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response, e)
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/member/api/MemberApi.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/member/api/MemberApi.kt
@@ -24,12 +24,12 @@ class MemberApi( private val memberService: MemberService,
     ) {
 
     @PostMapping("/join")
-    fun join(@RequestBody request: @Valid JoinRequest): ApiResponse<MemberResponse> {
+    fun join(@RequestBody @Valid request:  JoinRequest): ApiResponse<MemberResponse> {
         return ApiResponse.created(memberService.join(request.toServiceRequest()))
     }
 
     @PostMapping("/login")
-    fun login(@RequestBody request: @Valid LoginRequest, response: HttpServletResponse): ApiResponse<TokenResponse> {
+    fun login(@RequestBody @Valid request:  LoginRequest, response: HttpServletResponse): ApiResponse<TokenResponse> {
         val tokenResponse: TokenResponse = memberService.login(request.toServiceRequest())
         cookieService.setHeader(response, tokenResponse.refreshToken) // 쿠키에 refreshToken 저장
 
@@ -55,7 +55,7 @@ class MemberApi( private val memberService: MemberService,
     @PutMapping("/update")
     fun update(
         @AuthenticationPrincipal principalDetails: PrincipalDetails,
-        @RequestBody request: @Valid UpdateRequest
+        @RequestBody @Valid request: UpdateRequest
     ): ApiResponse<MemberResponse> {
         return ApiResponse.ok(memberService.update(principalDetails.member, request.toServiceRequest()))
     }
@@ -63,7 +63,7 @@ class MemberApi( private val memberService: MemberService,
     @PutMapping("/update-password")
     fun updatePassword(
         @AuthenticationPrincipal principalDetails: PrincipalDetails,
-        @RequestBody request: @Valid UpdatePasswordRequest
+        @RequestBody @Valid request: UpdatePasswordRequest
     ): ApiResponse<MemberResponse> {
         return ApiResponse.ok(memberService.updatePassword(principalDetails.member, request.toServiceRequest()))
     }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/member/api/request/JoinRequest.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/member/api/request/JoinRequest.kt
@@ -31,7 +31,6 @@ data class JoinRequest(
         regexp = "^010-\\d{3,4}-\\d{4}$",
         message = "휴대폰 번호는 010으로 시작하는 11자리 숫자와 '-'로 구성되어야 합니다."
     )
-    @field: NotBlank(message = "전화번호는 필수입니다.")
     val phoneNumber: String?,
     @field: NotNull(message = "loginProvider 는 필수입니다.")
     val loginProvider: LoginProvider?,

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/member/api/request/UpdatePasswordRequest.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/member/api/request/UpdatePasswordRequest.kt
@@ -12,13 +12,13 @@ data class UpdatePasswordRequest(
     @field: Pattern(
         regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,16}$",
         message = "비밀번호는 8~16자 사이  숫자, 영문자, 특수 문자를 각각 최소 한 개 이상 포함하여야 합니다."
-    ) @field: NotNull(message = "새 비밀번호를 입력하셔야 합니다.")
+    )
     val newPassword: String?,
 
     @field: Pattern(
         regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,16}$",
         message = "비밀번호는 8~16자 사이  숫자, 영문자, 특수 문자를 각각 최소 한 개 이상 포함하여야 합니다."
-    ) @field: NotNull(message = "새 비밀번호 확인을 입력하셔야 합니다.")
+    )
     val newPasswordConfirm:String?
 ) {
     fun toServiceRequest(): UpdatePasswordServiceRequest {

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/member/jwt/JwtTokenFilter.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/member/jwt/JwtTokenFilter.kt
@@ -16,7 +16,7 @@ import java.util.*
 @Component
 class JwtTokenFilter(private val jwtTokenUtil: JwtTokenUtil, private val redisTemplate: RedisTemplate<String, *>) : OncePerRequestFilter() {
 
-    private val EXCLUDED_URLS = listOf(
+    private final val excludedUrls = listOf(
         "/api/v1/members/join",
         "/api/v1/members/login",
         "/api/v1/court/",
@@ -24,8 +24,9 @@ class JwtTokenFilter(private val jwtTokenUtil: JwtTokenUtil, private val redisTe
         "/api/v1/merchant/",
     )
 
+
     @Throws(ServletException::class, IOException::class)
-    protected override fun doFilterInternal(
+    override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain
@@ -34,8 +35,8 @@ class JwtTokenFilter(private val jwtTokenUtil: JwtTokenUtil, private val redisTe
             filterChain.doFilter(request, response)
         }
 
-        val accessToken = jwtTokenUtil.getHeaderToken(request, ACCESS_TOKEN)
-        val refreshToken = getRefreshTokenByRequest(request) ?: jwtTokenUtil.getHeaderToken(request, REFRESH_TOKEN)
+        val accessToken = jwtTokenUtil.getHeaderToken(request, JwtTokenUtil.ACCESS_TOKEN)
+        val refreshToken = getRefreshTokenByRequest(request) ?: jwtTokenUtil.getHeaderToken(request, JwtTokenUtil.REFRESH_TOKEN)
 
         processSecurity(accessToken, refreshToken)
         filterChain.doFilter(request, response)
@@ -68,15 +69,12 @@ class JwtTokenFilter(private val jwtTokenUtil: JwtTokenUtil, private val redisTe
 
 
     companion object {
-        const val ACCESS_TOKEN: String = "Authorization"
-        const val REFRESH_TOKEN: String = "refresh_token"
-        private const val COOKIE_REFRESH_TOKEN = "refreshToken"
         fun getRefreshTokenByRequest(request: HttpServletRequest): String? {
             val cookies: Array<Cookie>? = request.cookies
 
             if (!cookies.isNullOrEmpty()) {
                 return Arrays.stream(cookies)
-                    .filter { c: Cookie -> c.name == COOKIE_REFRESH_TOKEN }.findFirst().map { obj: Cookie -> obj.value }
+                    .filter { c: Cookie -> c.name == JwtTokenUtil.COOKIE_REFRESH_TOKEN }.findFirst().map { obj: Cookie -> obj.value }
                     .orElse(null)
             }
 
@@ -85,7 +83,7 @@ class JwtTokenFilter(private val jwtTokenUtil: JwtTokenUtil, private val redisTe
     }
 
     private fun isExcludedUrl(requestURI: String): Boolean {
-        return EXCLUDED_URLS.any { requestURI.startsWith(it) }
+        return excludedUrls.any { requestURI.startsWith(it) }
     }
 
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/member/jwt/JwtTokenUtil.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/member/jwt/JwtTokenUtil.kt
@@ -151,6 +151,7 @@ class JwtTokenUtil(private val userDetailService: PrincipalDetailsService, priva
     companion object {
         const val ACCESS_TOKEN: String = "Authorization"
         const val REFRESH_TOKEN: String = "refresh_token"
+        const val COOKIE_REFRESH_TOKEN = "refreshToken"
         const val BEARER_PREFIX: String = "Bearer "
         val ACCESS_TIME: Long = Duration.ofMinutes(30).toMillis() // 만료시간 30분
         val REFRESH_TIME: Long = Duration.ofDays(14).toMillis() // 만료시간 2주

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/member/jwt/JwtTokenUtil.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/member/jwt/JwtTokenUtil.kt
@@ -139,12 +139,13 @@ class JwtTokenUtil(private val userDetailService: PrincipalDetailsService, priva
         }
     }
 
-    fun refreshTokenValidation(refreshToken: String?) {
+    fun refreshTokenValidation(refreshToken: String?): Boolean {
         tokenValidation(refreshToken)
         val email = getEmailFromToken(refreshToken)
         val redisRefresh = redisTemplate.opsForValue()[email]
 
-        redisRefresh?.toString() ?: throw JwtException("유효하지 않은 Jwt 토큰입니다.")
+        redisRefresh?.toString() ?: return false
+        return true
     }
 
     companion object {

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/member/oauth2/handler/CustomOAuth2LoginFailureHandler.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/member/oauth2/handler/CustomOAuth2LoginFailureHandler.kt
@@ -1,0 +1,26 @@
+package com.grepp.nbe1_3_team04.member.oauth2.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.grepp.nbe1_3_team04.global.api.ApiResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
+import org.springframework.stereotype.Component
+
+@Component
+class CustomOAuth2LoginFailureHandler : AuthenticationFailureHandler {
+    private val objectMapper = ObjectMapper()
+
+    override fun onAuthenticationFailure(request: HttpServletRequest?, response: HttpServletResponse?, exception: AuthenticationException?) {
+        response?.status = HttpServletResponse.SC_UNAUTHORIZED
+        response?.contentType = "application/json"
+        response?.characterEncoding = "UTF-8"
+
+        val apiResponse = ApiResponse.of(HttpStatus.UNAUTHORIZED, "로그인 실패", null)
+        val jsonResponse = objectMapper.writeValueAsString(apiResponse)
+
+        response?.writer?.write(jsonResponse)
+    }
+}

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/member/oauth2/handler/CustomOAuth2LoginSuccessHandler.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/member/oauth2/handler/CustomOAuth2LoginSuccessHandler.kt
@@ -1,4 +1,4 @@
-package com.grepp.nbe1_3_team04.member.oauth2
+package com.grepp.nbe1_3_team04.member.oauth2.handler
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.grepp.nbe1_3_team04.global.api.ApiResponse
@@ -6,6 +6,7 @@ import com.grepp.nbe1_3_team04.member.domain.Member
 import com.grepp.nbe1_3_team04.member.domain.MemberRole
 import com.grepp.nbe1_3_team04.member.jwt.JwtTokenUtil
 import com.grepp.nbe1_3_team04.member.jwt.response.TokenResponse
+import com.grepp.nbe1_3_team04.member.oauth2.CustomOAuth2UserDetails
 import com.grepp.nbe1_3_team04.member.oauth2.response.MemberOAuthResponse
 import com.grepp.nbe1_3_team04.member.service.CookieService
 import jakarta.servlet.ServletException


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 인증이 필요 없는 url 의 경우 JwtFilter 를 타지 않게 변경 (refreshToken 이 자꾸 인증에 걸려서 없는 이메일 뜨는 거 고쳤습니다.)
- 인증 실패시 OAuth 를 통해 html 코드가 response 로 오던 것을 수정
- 새로운 응답 추가
- kotlin 리팩토링
- memberApi @Valid 유효성 검사가 안되던 버그 수정

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #83 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
뭐가 자꾸 추가가 되네요.. 시큐리티 뭔가 Spring 안에서 작동하는게 많은 거 같아서 복잡합니다 ㅠㅠ 한 번 제대로 공부하는 시간도 있어야 할 것 같아요... 새로운 인증 관련 실패 handler 들을 추가해서 이제 아마 http 응답이 안갈 겁니다. 가면 말씀 좀 해주세요


