### PR TITLE
[Feat/#84] 채팅 redis 캐싱 및 벌크 인서트 구현

### DIFF
--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatApi.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatApi.kt
@@ -7,7 +7,6 @@ import com.grepp.nbe1_3_team04.chat.service.response.ChatResponse
 import com.grepp.nbe1_3_team04.global.api.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Slice
 import org.springframework.data.domain.Sort
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.MessageMapping
@@ -45,7 +44,7 @@ class ChatApi(
         @RequestParam cursor: LocalDateTime?,
         @RequestParam size: Int,
         @AuthenticationPrincipal principalDetails: PrincipalDetails
-    ): ApiResponse<Slice<ChatResponse>> {
+    ): ApiResponse<List<ChatResponse>> {
         val pageRequest = PageRequest.of(0, size, Sort.by("createdAt").descending())
         return ApiResponse.ok(chatService.getChatList(chatroomId, pageRequest, principalDetails.member, cursor))
     }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatApi.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatApi.kt
@@ -56,7 +56,7 @@ class ChatApi(
     @PutMapping("/{chatId}")
     fun updateChatting(
         @PathVariable chatId: Long,
-        @RequestBody request: @Valid ChatUpdateRequest,
+        @RequestBody @Valid request: ChatUpdateRequest,
         @AuthenticationPrincipal principalDetails: PrincipalDetails
     ): ApiResponse<ChatResponse> {
         return ApiResponse.ok(

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatApi.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatApi.kt
@@ -14,6 +14,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import team4.footwithme.member.jwt.PrincipalDetails
+import java.time.LocalDateTime
 
 
 @RestController
@@ -41,12 +42,12 @@ class ChatApi(
     @GetMapping("/{chatroomId}")
     fun getChatting(
         @PathVariable chatroomId: Long,
-        @RequestParam page: Int,
+        @RequestParam cursor: LocalDateTime?,
         @RequestParam size: Int,
         @AuthenticationPrincipal principalDetails: PrincipalDetails
     ): ApiResponse<Slice<ChatResponse>> {
-        val pageRequest = PageRequest.of(page - 1, size, Sort.by("createdAt").descending())
-        return ApiResponse.ok(chatService.getChatList(chatroomId, pageRequest, principalDetails.member))
+        val pageRequest = PageRequest.of(0, size, Sort.by("createdAt").descending())
+        return ApiResponse.ok(chatService.getChatList(chatroomId, pageRequest, principalDetails.member, cursor))
     }
 
     /**

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatMemberApi.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatMemberApi.kt
@@ -18,7 +18,7 @@ class ChatMemberApi(
      * 채팅방 초대
      */
     @PostMapping
-    fun inviteChatMember(@RequestBody chatMemberRequest: @Valid ChatMemberRequest): ApiResponse<ChatMemberResponse> {
+    fun inviteChatMember(@RequestBody @Valid chatMemberRequest: ChatMemberRequest): ApiResponse<ChatMemberResponse> {
         return ApiResponse.created(chatMemberService.joinChatMember(chatMemberRequest.toServiceRequest()))
     }
 
@@ -26,7 +26,7 @@ class ChatMemberApi(
      * 채팅방 나감
      */
     @DeleteMapping
-    fun removeChatMember(@RequestBody chatMemberRequest: @Valid ChatMemberRequest): ApiResponse<ChatMemberResponse> {
+    fun removeChatMember(@RequestBody @Valid chatMemberRequest: ChatMemberRequest): ApiResponse<ChatMemberResponse> {
         return ApiResponse.ok(chatMemberService.leaveChatMember(chatMemberRequest.toServiceRequest()))
     }
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatroomApi.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/api/ChatroomApi.kt
@@ -21,7 +21,7 @@ class ChatroomApi(
      * 팀, 예약 생성시 같이 실행해주기
      */
     @PostMapping
-    fun createChatroom(@RequestBody chatroomRequest: @Valid ChatroomRequest): ApiResponse<ChatroomResponse> {
+    fun createChatroom(@RequestBody @Valid chatroomRequest: ChatroomRequest): ApiResponse<ChatroomResponse> {
         return ApiResponse.created(chatroomService.createChatroom(chatroomRequest.toServiceRequest()))
     }
 
@@ -39,7 +39,7 @@ class ChatroomApi(
     @PutMapping("/{chatroomId}")
     fun updateChatroom(
         @PathVariable("chatroomId") chatroomId: Long,
-        @RequestBody chatroomRequest: @Valid ChatroomRequest
+        @RequestBody @Valid chatroomRequest: ChatroomRequest
     ): ApiResponse<ChatroomResponse> {
         return ApiResponse.ok(chatroomService.updateChatroom(chatroomId, chatroomRequest.toServiceRequest()))
     }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/ChatJDBCRepository.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/ChatJDBCRepository.kt
@@ -1,9 +1,11 @@
 package com.grepp.nbe1_3_team04.chat.repository
 
 import com.grepp.nbe1_3_team04.chat.domain.Chat
+import com.grepp.nbe1_3_team04.global.exception.ExceptionMessage
 import org.springframework.jdbc.core.BatchPreparedStatementSetter
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import java.sql.PreparedStatement
 import java.sql.Timestamp
 
@@ -12,28 +14,33 @@ class ChatJDBCRepository(
     private val jdbcTemplate: JdbcTemplate
 ) {
 
+    @Transactional
     fun batchInsert(list: List<Chat>){
         val sql = """
             INSERT INTO chat (chat_type, text, chatroom_id, member_id, created_at, is_deleted, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?)
         """.trimIndent()
 
-        jdbcTemplate.batchUpdate(
-             sql, object : BatchPreparedStatementSetter {
-            override fun setValues(ps: PreparedStatement, i: Int) {
-                ps.setString(1, list[i].chatType.name)
-                ps.setString(2, list[i].text)
-                ps.setLong(3, requireNotNull(list[i].chatroom.chatroomId) { "Chatroom ID cannot be null" })
-                ps.setLong(4, requireNotNull(list[i].member.memberId) { "Member ID cannot be null" })
-                ps.setTimestamp(5, list[i].createdAt?.let { Timestamp.valueOf(it) })
-                ps.setString(6, list[i].isDeleted.name)
-                ps.setTimestamp(7, list[i].updatedAt?.let { Timestamp.valueOf(it) })
-            }
+        try {
+            jdbcTemplate.batchUpdate(
+                 sql, object : BatchPreparedStatementSetter {
+                override fun setValues(ps: PreparedStatement, i: Int) {
+                    ps.setString(1, list[i].chatType.name)
+                    ps.setString(2, list[i].text)
+                    ps.setLong(3, requireNotNull(list[i].chatroom.chatroomId) { "Chatroom ID cannot be null" })
+                    ps.setLong(4, requireNotNull(list[i].member.memberId) { "Member ID cannot be null" })
+                    ps.setTimestamp(5, list[i].createdAt?.let { Timestamp.valueOf(it) })
+                    ps.setString(6, list[i].isDeleted.name)
+                    ps.setTimestamp(7, list[i].updatedAt?.let { Timestamp.valueOf(it) })
+                }
 
-            override fun getBatchSize(): Int {
-                return list.size
-            }
-        })
+                override fun getBatchSize(): Int {
+                    return list.size
+                }
+            })
+        } catch (e: Exception) {
+            throw IllegalArgumentException(ExceptionMessage.CANNOT_BATCH_INSERT.text)
+        }
     }
 
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/ChatJDBCRepository.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/ChatJDBCRepository.kt
@@ -1,0 +1,39 @@
+package com.grepp.nbe1_3_team04.chat.repository
+
+import com.grepp.nbe1_3_team04.chat.domain.Chat
+import org.springframework.jdbc.core.BatchPreparedStatementSetter
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.PreparedStatement
+import java.sql.Timestamp
+
+@Repository
+class ChatJDBCRepository(
+    private val jdbcTemplate: JdbcTemplate
+) {
+
+    fun batchInsert(list: List<Chat>){
+        val sql = """
+            INSERT INTO chat (chat_type, text, chatroom_id, member_id, created_at, is_deleted, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+
+        jdbcTemplate.batchUpdate(
+             sql, object : BatchPreparedStatementSetter {
+            override fun setValues(ps: PreparedStatement, i: Int) {
+                ps.setString(1, list[i].chatType.name)
+                ps.setString(2, list[i].text)
+                ps.setLong(3, requireNotNull(list[i].chatroom.chatroomId) { "Chatroom ID cannot be null" })
+                ps.setLong(4, requireNotNull(list[i].member.memberId) { "Member ID cannot be null" })
+                ps.setTimestamp(5, list[i].createdAt?.let { Timestamp.valueOf(it) })
+                ps.setString(6, list[i].isDeleted.name)
+                ps.setTimestamp(7, list[i].updatedAt?.let { Timestamp.valueOf(it) })
+            }
+
+            override fun getBatchSize(): Int {
+                return list.size
+            }
+        })
+    }
+
+}

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/ChatRepository.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/ChatRepository.kt
@@ -1,9 +1,11 @@
 package com.grepp.nbe1_3_team04.chat.repository
 
 import com.grepp.nbe1_3_team04.chat.domain.Chat
+import io.lettuce.core.dynamic.annotation.Param
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface ChatRepository : JpaRepository<Chat, Long>, CustomChatRepository {
@@ -12,4 +14,7 @@ interface ChatRepository : JpaRepository<Chat, Long>, CustomChatRepository {
 
     @Query("select c from Chat c where c.isDeleted = 'false' and c.chatId = ?1")
     fun findByChatId(chatId: Long): Chat?
+
+    @Query("SELECT c FROM Chat c WHERE c.isDeleted = 'false' AND c.createdAt >= :date")
+    fun findAllByCreatedAtAfter(@Param("date") date: LocalDateTime): List<Chat>
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/CustomChatRepository.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/CustomChatRepository.kt
@@ -4,7 +4,8 @@ import com.grepp.nbe1_3_team04.chat.domain.Chatroom
 import com.grepp.nbe1_3_team04.chat.service.response.ChatResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
+import java.time.LocalDateTime
 
 interface CustomChatRepository {
-    fun findChatByChatroom(chatroom: Chatroom, pageable: Pageable): Slice<ChatResponse>
+    fun findChatByChatroom(chatroom: Chatroom, pageable: Pageable, cursor: LocalDateTime?): Slice<ChatResponse>
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/CustomChatRepository.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/CustomChatRepository.kt
@@ -1,5 +1,6 @@
 package com.grepp.nbe1_3_team04.chat.repository
 
+import com.grepp.nbe1_3_team04.chat.domain.Chat
 import com.grepp.nbe1_3_team04.chat.domain.Chatroom
 import com.grepp.nbe1_3_team04.chat.service.response.ChatResponse
 import org.springframework.data.domain.Pageable
@@ -7,5 +8,7 @@ import org.springframework.data.domain.Slice
 import java.time.LocalDateTime
 
 interface CustomChatRepository {
-    fun findChatByChatroom(chatroom: Chatroom, pageable: Pageable, cursor: LocalDateTime?): Slice<ChatResponse>
+    fun findChatByChatroomPage(chatroom: Chatroom, pageable: Pageable, cursor: LocalDateTime?): Slice<ChatResponse>
+
+    fun findChatByChatroomList(chatroom: Chatroom, limit: Int, cursor: LocalDateTime?): MutableList<Chat>
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/CustomChatRepositoryImpl.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/repository/CustomChatRepositoryImpl.kt
@@ -51,8 +51,7 @@ class CustomChatRepositoryImpl (
                     .and(chat.chatroom.eq(chatroom))
                     .let {
                         // 커서가 있는 경우, createdAt이 커서보다 작은 항목만 가져옴
-                        if (cursor != null) it.and(chat.createdAt.lt(cursor))
-                        else it
+                        cursor?.let { cur -> it.and(chat.createdAt.lt(cur)) } ?: it
                     }
             )
             .orderBy(chat.createdAt.desc())
@@ -69,8 +68,7 @@ class CustomChatRepositoryImpl (
                     .and(chat.chatroom.eq(chatroom))
                     .let {
                         // 커서가 있는 경우, createdAt이 커서보다 작은 항목만 가져옴
-                        if (cursor != null) it.and(chat.createdAt.lt(cursor))
-                        else it
+                        cursor?.let { cur -> it.and(chat.createdAt.lt(cur)) } ?: it
                     }
             )
             .orderBy(chat.createdAt.desc())

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatMemberServiceImpl.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatMemberServiceImpl.kt
@@ -243,7 +243,7 @@ class ChatMemberServiceImpl(
 
     // localDateTime을 Redis에서 사용할 수 있게 double로 변경
     fun localDateTimeToDouble(cursor: LocalDateTime?): Double {
-        return cursor?.atZone(ZoneId.of("UTC"))?.toInstant()?.toEpochMilli()?.toDouble()
-            ?: throw IllegalArgumentException("생성시간은 null 일 수 없습니다.")
+        return cursor?.atZone(ZoneId.systemDefault())?.toInstant()?.toEpochMilli()?.toDouble()
+            ?: throw IllegalArgumentException(ExceptionMessage.REQUIRE_NOT_NULL_CREATED_AT.text)
     }
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatMemberServiceImpl.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatMemberServiceImpl.kt
@@ -4,7 +4,6 @@ import com.grepp.nbe1_3_team04.chat.domain.Chat
 import com.grepp.nbe1_3_team04.chat.domain.ChatMember
 import com.grepp.nbe1_3_team04.chat.domain.Chatroom
 import com.grepp.nbe1_3_team04.chat.repository.ChatMemberRepository
-import com.grepp.nbe1_3_team04.chat.repository.ChatRepository
 import com.grepp.nbe1_3_team04.chat.repository.ChatroomRepository
 import com.grepp.nbe1_3_team04.chat.service.request.ChatMemberServiceRequest
 import com.grepp.nbe1_3_team04.chat.service.response.ChatMemberResponse
@@ -13,8 +12,11 @@ import com.grepp.nbe1_3_team04.member.domain.Member
 import com.grepp.nbe1_3_team04.member.repository.MemberRepository
 import com.grepp.nbe1_3_team04.reservation.domain.Participant
 import com.grepp.nbe1_3_team04.team.domain.TeamMember
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 
 @Service
@@ -22,8 +24,8 @@ class ChatMemberServiceImpl(
     private val chatMemberRepository: ChatMemberRepository,
     private val memberRepository: MemberRepository,
     private val chatroomRepository: ChatroomRepository,
-    private val chatRepository: ChatRepository,
-    private val redisPublisher: RedisPublisher
+    private val redisPublisher: RedisPublisher,
+    private val redisTemplate: RedisTemplate<String, Chat>
 ) : ChatMemberService {
 
     /**
@@ -60,7 +62,10 @@ class ChatMemberServiceImpl(
         val chatMember: ChatMember = chatMemberRepository.save(ChatMember.create(member, chatroom))
 
         val chat = Chat.createEnterChat(chatroom, member)
-        chatRepository.save(chat)
+        chat.updateTimeToNow()
+
+        // redis에 채팅 저장
+        saveChatInRedis(chat)
 
         redisPublisher.publish(chat)
 
@@ -116,7 +121,10 @@ class ChatMemberServiceImpl(
         chatMemberRepository.saveAll(chatMembers)
 
         val chat = Chat.createGroupEnterChat(chatroom, chatMembers)
-        chatRepository.save(chat)
+        chat.updateTimeToNow()
+
+        // redis에 채팅 저장
+        saveChatInRedis(chat)
 
         redisPublisher.publish(chat)
     }
@@ -155,7 +163,10 @@ class ChatMemberServiceImpl(
         chatMemberRepository.deleteByMemberAndChatroom(member, chatroom)
 
         val chat = Chat.createQuitChat(chatroom, member)
-        chatRepository.save(chat)
+        chat.updateTimeToNow()
+
+        // redis에 채팅 저장
+        saveChatInRedis(chat)
 
         redisPublisher.publish(chat)
 
@@ -221,5 +232,18 @@ class ChatMemberServiceImpl(
 
     private fun getChatroomByReservationId(reservationId: Long): Chatroom {
         return chatroomRepository.findByReservationId(reservationId) ?: throw IllegalArgumentException(ExceptionMessage.CHATROOM_NOT_FOUND.text)
+    }
+
+    // 채팅을 redis에 저장
+    private fun saveChatInRedis(chat: Chat) {
+        val key = "chatroom:${chat.chatroom.chatroomId}:new"
+        val score = localDateTimeToDouble(chat.createdAt)
+        redisTemplate.opsForZSet().add(key, chat, score)
+    }
+
+    // localDateTime을 Redis에서 사용할 수 있게 double로 변경
+    fun localDateTimeToDouble(cursor: LocalDateTime?): Double {
+        return cursor?.atZone(ZoneId.of("UTC"))?.toInstant()?.toEpochMilli()?.toDouble()
+            ?: throw IllegalArgumentException("생성시간은 null 일 수 없습니다.")
     }
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatService.kt
@@ -11,7 +11,7 @@ import java.time.LocalDateTime
 interface ChatService {
     fun sendMessage(request: ChatServiceRequest, token: String)
 
-    fun getChatList(chatroomId: Long, pageRequest: PageRequest, member: Member, cursor: LocalDateTime?): Slice<ChatResponse>
+    fun getChatList(chatroomId: Long, pageRequest: PageRequest, member: Member, cursor: LocalDateTime?): List<ChatResponse>
 
     fun updateChat(request: ChatUpdateServiceRequest, member: Member, chatId: Long): ChatResponse
 

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatService.kt
@@ -6,11 +6,12 @@ import com.grepp.nbe1_3_team04.chat.service.response.ChatResponse
 import com.grepp.nbe1_3_team04.member.domain.Member
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
+import java.time.LocalDateTime
 
 interface ChatService {
     fun sendMessage(request: ChatServiceRequest, token: String)
 
-    fun getChatList(chatroomId: Long, pageRequest: PageRequest, member: Member): Slice<ChatResponse>
+    fun getChatList(chatroomId: Long, pageRequest: PageRequest, member: Member, cursor: LocalDateTime?): Slice<ChatResponse>
 
     fun updateChat(request: ChatUpdateServiceRequest, member: Member, chatId: Long): ChatResponse
 

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatServiceImpl.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatServiceImpl.kt
@@ -16,6 +16,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 
 @Service
@@ -57,11 +58,11 @@ class ChatServiceImpl(
      * 채팅방 메세지를 보려면 채팅방에 소속된 멤버여야 함
      */
     @Transactional(readOnly = true)
-    override fun getChatList(chatroomId: Long, pageRequest: PageRequest, member: Member): Slice<ChatResponse> {
+    override fun getChatList(chatroomId: Long, pageRequest: PageRequest, member: Member, cursor: LocalDateTime?): Slice<ChatResponse> {
         val chatroom = getChatroom(chatroomId)
         checkMemberInChatroom(member, chatroom)
 
-        return chatRepository.findChatByChatroom(chatroom, pageRequest)
+        return chatRepository.findChatByChatroom(chatroom, pageRequest, cursor)
     }
 
     /**

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatServiceImpl.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/ChatServiceImpl.kt
@@ -202,7 +202,7 @@ class ChatServiceImpl(
 
     ////////////////////// 새로운 채팅 batch Insert /////////////////////////
 
-    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    @Scheduled(cron = "0 30 * * * *") // 1시간마다 실행
     fun batchInsertChatMessages() {
         val currentTimestamp = Instant.now().toEpochMilli().toDouble()
         val chatRoomIds = chatroomRepository.findAll().map { it.chatroomId }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/response/ChatResponse.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/chat/service/response/ChatResponse.kt
@@ -6,7 +6,6 @@ import com.grepp.nbe1_3_team04.global.exception.ExceptionMessage
 import java.time.LocalDateTime
 
 data class ChatResponse(
-    val chatId: Long,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
     val chatroomResponse: ChatroomResponse,
@@ -15,7 +14,6 @@ data class ChatResponse(
     val text: String
 ) {
     constructor(chat: Chat) : this(
-        requireNotNull(chat.chatId) { ExceptionMessage.REQUIRE_NOT_NULL_ID.text},
         requireNotNull(chat.createdAt) {ExceptionMessage.REQUIRE_NOT_NULL_CREATED_AT.text},
         requireNotNull(chat.updatedAt) {ExceptionMessage.REQUIRE_NOT_NULL_UPDATED_AT.text},
         ChatroomResponse(chat.chatroom),

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/config/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/config/redis/RedisConfig.kt
@@ -1,11 +1,12 @@
 package com.grepp.nbe1_3_team04.config.redis
 
+import com.grepp.nbe1_3_team04.chat.domain.Chat
 import com.grepp.nbe1_3_team04.chat.service.RedisSubscriber
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.connection.RedisConnectionFactory
-import org.springframework.data.redis.core.HashOperations
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.listener.ChannelTopic
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
 @Configuration
 @EnableRedisRepositories
 @EnableTransactionManagement
+@EnableCaching
 class RedisConfig {
     //redis pub/sub 사용할 때의 chatting Topic
     @Bean
@@ -52,6 +54,16 @@ class RedisConfig {
         redisTemplate.connectionFactory = connectionFactory
         redisTemplate.keySerializer = StringRedisSerializer()
         redisTemplate.valueSerializer = Jackson2JsonRedisSerializer(String::class.java)
+        redisTemplate.setEnableTransactionSupport(true)
+        return redisTemplate
+    }
+
+    @Bean
+    fun chatRedisTemplate(connectionFactory: RedisConnectionFactory?): RedisTemplate<String, Chat> {
+        val redisTemplate = RedisTemplate<String, Chat>()
+        redisTemplate.connectionFactory = connectionFactory
+        redisTemplate.keySerializer = StringRedisSerializer()
+        redisTemplate.valueSerializer = Jackson2JsonRedisSerializer(Chat::class.java) // Chat에 맞춘 직렬화
         redisTemplate.setEnableTransactionSupport(true)
         return redisTemplate
     }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/global/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/global/domain/BaseEntity.kt
@@ -33,8 +33,8 @@ abstract class BaseEntity {
     var isDeleted = IsDeleted.FALSE
 
     fun updateTimeToNow(){
-        createdAt = ZonedDateTime.now(ZoneId.of("UTC")).toLocalDateTime()
-        updatedAt = ZonedDateTime.now(ZoneId.of("UTC")).toLocalDateTime()
+        createdAt = ZonedDateTime.now(ZoneId.systemDefault()).toLocalDateTime()
+        updatedAt = ZonedDateTime.now(ZoneId.systemDefault()).toLocalDateTime()
     }
 
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/global/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/global/domain/BaseEntity.kt
@@ -4,15 +4,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
-import jakarta.persistence.Column
-import jakarta.persistence.EntityListeners
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
-import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.*
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class) // 스프링 데이터 JPA의 감사 기능 -> 엔티티가 생성/수정 될때 자동으로 설정
@@ -33,5 +31,10 @@ abstract class BaseEntity {
 
     @Enumerated(EnumType.STRING)
     var isDeleted = IsDeleted.FALSE
+
+    fun updateTimeToNow(){
+        createdAt = ZonedDateTime.now(ZoneId.of("UTC")).toLocalDateTime()
+        updatedAt = ZonedDateTime.now(ZoneId.of("UTC")).toLocalDateTime()
+    }
 
 }

--- a/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/ExceptionMessage.kt
+++ b/src/main/kotlin/com/grepp/nbe1_3_team04/global/exception/ExceptionMessage.kt
@@ -49,7 +49,10 @@ enum class ExceptionMessage(text: String) {
     //global
     REQUIRE_NOT_NULL_ID("ID는 Null일 수 없습니다."),
     REQUIRE_NOT_NULL_CREATED_AT("생성일은 Null일 수 없습니다."),
-    REQUIRE_NOT_NULL_UPDATED_AT("수정일은 Null일 수 없습니다.");
+    REQUIRE_NOT_NULL_UPDATED_AT("수정일은 Null일 수 없습니다."),
+
+    CANNOT_BATCH_INSERT("채팅 Batch Insert중 오류가 발생했습니다.")
+    ;
 
 
     val text: String = text


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 채팅 저장 시 redis 캐시에 저장
- 1시간마다 redis 캐시에 있는 새로운 채팅을 벌크 인서트
- redis 캐시에 있는 데이터로 채팅 조회
- 캐시에 존재하지 않을 경우 db에서 조회 후 캐시에 저장
- 스케줄링을 통해 redis와 db 동기화

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #84
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
캐시는 처음 다뤄봐서 잘 짠건지 모르곘네요

모든 로직들이 너무 채팅 서비스에 몰려있어서 리팩토링이 필요해보입니다

postman에서 동작하는건 확인했는데 1주일마다 동기화시켜주는건 확인 못해봤습니다.

피드백 주시면 감사히 받겠습니다!
